### PR TITLE
Performance improvements

### DIFF
--- a/Plutarch/Internal/Term.hs
+++ b/Plutarch/Internal/Term.hs
@@ -1,6 +1,13 @@
 {-# LANGUAGE RoleAnnotations #-}
 {-# LANGUAGE ViewPatterns #-}
 
+-- NOTE: (choener) We have a set of conditional compilations in this module
+
+{-# OPTIONS_GHC -Wno-unused-top-binds #-}
+{-# OPTIONS_GHC -Wno-unused-imports #-}
+{-# OPTIONS_GHC -Wno-redundant-constraints #-}
+{-# OPTIONS_GHC -Wno-unused-matches #-}
+
 module Plutarch.Internal.Term (
   -- | \$hoisted
   (:-->) (PLam),
@@ -89,6 +96,9 @@ import PlutusCore.DeBruijn (DeBruijn (DeBruijn), Index (Index))
 import PlutusLedgerApi.Common (serialiseUPLC)
 import Prettyprinter (Pretty (pretty), (<+>))
 import UntypedPlutusCore qualified as UPLC
+import Data.Hashable (Hashable (..), defaultHashWithSalt)
+import qualified Data.HashMap.Strict as HM
+import System.IO.Unsafe (unsafePerformIO)
 
 {- $hoisted
  __Explanation for hoisted terms:__
@@ -105,10 +115,38 @@ import UntypedPlutusCore qualified as UPLC
  though the name is relative to the current level.
 -}
 
-type Dig = Digest Blake2b_160
+-- NOTE: (choener) We keep the type field for the digest around, even when the
+-- old compilation pipeline is disabled. However in that case, the digest
+-- becomes a unit type, being mostly free.
 
-data HoistedTerm = HoistedTerm Dig RawTerm
+#ifdef CMPOLD
+type Dig = Digest Blake2b_160
+#else
+type Dig = ()
+#endif
+
+data HoistedTerm = HoistedTerm { htDig :: Dig, htHash :: Int, htRawTerm :: RawTerm }
   deriving stock (Show)
+
+-- | Hoisted term carry their own non-cryptographic hash, making it incredibly
+-- cheap to hold these in hashmaps.
+
+instance Hashable HoistedTerm where
+  hashWithSalt = defaultHashWithSalt
+  {-# Inline hashWithSalt #-}
+  -- The instance uses that this is basically 'Hashed a'.
+  hash = htHash
+  {-# Inline hash #-}
+
+-- | Equality of hoisted terms is first checked via their non-cryptographic
+-- hash, then via term equality. Inequality, which should happen much more
+-- often is thus cheap.
+
+instance Eq HoistedTerm where
+  -- TODO: Consider if Eq might benefit from using the Dig, I don't think so.
+  l == r =  htHash l == htHash r
+         && htRawTerm l == htRawTerm r
+  {-# Inline (==) #-}
 
 type UTerm = UPLC.Term UPLC.DeBruijn UPLC.DefaultUni UPLC.DefaultFun ()
 
@@ -126,11 +164,40 @@ data RawTerm
   | RPlaceHolder Integer
   | RConstr Word64 [RawTerm]
   | RCase RawTerm [RawTerm]
-  deriving stock (Show)
+  deriving stock (Show,Eq)
+
+-- | Hashing of raw terms somewhat follows cryptographic hashing. The
+-- non-cryptographic hash is much cheaper to calculate.
+
+instance Hashable RawTerm where
+  hashWithSalt = defaultHashWithSalt
+  {-# Inline hashWithSalt #-}
+  hash = {-# SCC "Hashable" #-} \case
+    RVar x -> hash (0 :: Int, fromIntegral x :: Int)
+    RLamAbs n x -> hash (1 :: Int, n, x)
+    RApply x y -> hash (2 :: Int, x:y)
+    RForce x -> hash (3 :: Int, x)
+    RDelay x -> hash (4 :: Int, x)
+    RConstant x -> hash (5 :: Int, x)
+    RBuiltin x -> hash (6 :: Int, x)
+    RError -> 7 :: Int
+    RHoisted (HoistedTerm{htHash}) -> hash (8 :: Int, htHash :: Int)
+    RCompiled code -> hash (9 :: Int, code)
+    RPlaceHolder x -> hash (10 :: Int, x)
+    RConstr x y -> hash (11 :: Int, x, y)
+    RCase x y -> hash (12 :: Int, x, y)
+  {-# Inline hash #-}
 
 addHashIndex :: forall alg. HashAlgorithm alg => Integer -> Context alg -> Context alg
 addHashIndex i = flip hashUpdate ((fromString $ show i) :: BS.ByteString)
 
+-- TODO: (choener) Currently, the whole digest calculation is off, unless
+-- CMPOLD is active. We probably want to switch this back on, but have an ifdef
+-- around RHoisted, either using the existing hash of recursively compiling
+-- (but making sure the same hash is computed!!!). This way, cryptographic
+-- hashing can be used downstream.
+
+#ifdef CMPOLD
 hashUTerm :: forall alg. HashAlgorithm alg => UTerm -> Context alg -> Context alg
 hashUTerm (UPLC.Var _ name) = addHashIndex 0 . flip hashUpdate (F.flat name)
 hashUTerm (UPLC.LamAbs _ name uterm) = addHashIndex 1 . flip hashUpdate (F.flat name) . hashUTerm uterm
@@ -155,16 +222,21 @@ hashRawTerm' (RDelay x) = addHashIndex 4 . hashRawTerm' x
 hashRawTerm' (RConstant x) = addHashIndex 5 . flip hashUpdate (F.flat x)
 hashRawTerm' (RBuiltin x) = addHashIndex 6 . flip hashUpdate (F.flat x)
 hashRawTerm' RError = addHashIndex 7
-hashRawTerm' (RHoisted (HoistedTerm hash _)) = addHashIndex 8 . flip hashUpdate hash
+hashRawTerm' (RHoisted (HoistedTerm{htDig})) = addHashIndex 8 . flip hashUpdate htDig
 hashRawTerm' (RCompiled code) = addHashIndex 9 . flip hashUpdate (hashUTerm @alg code hashInit)
 hashRawTerm' (RPlaceHolder x) = addHashIndex 10 . addHashIndex x
 hashRawTerm' (RConstr x y) =
   addHashIndex 11 . flip hashUpdate (F.flat (fromIntegral x :: Integer)) . flip (foldl' $ flip hashRawTerm') y
 hashRawTerm' (RCase x y) =
   addHashIndex 12 . hashRawTerm' x . flip (foldl' $ flip hashRawTerm') y
+#endif
 
 hashRawTerm :: RawTerm -> Dig
+#ifdef CMPOLD
 hashRawTerm t = hashFinalize . hashRawTerm' t $ hashInit
+#else
+hashRawTerm _ = ()
+#endif
 
 data TermResult = TermResult
   { getTerm :: RawTerm
@@ -513,8 +585,8 @@ plam' f = Term \i ->
     getArity :: RawTerm -> Maybe Word64
     -- We only do this if it's hoisted, since it's only safe if it doesn't
     -- refer to any of the variables in the wrapping lambda.
-    getArity (RHoisted (HoistedTerm _ (RLamAbs n _))) = Just n
-    getArity (RHoisted (HoistedTerm _ t)) = getArityBuiltin t
+    getArity (RHoisted (HoistedTerm _ _ (RLamAbs n _))) = Just n
+    getArity (RHoisted (HoistedTerm _ _ t)) = getArityBuiltin t
     getArity t = getArityBuiltin t
 
     getArityBuiltin :: RawTerm -> Maybe Word64
@@ -641,7 +713,7 @@ papp x y = Term \i ->
     (_, getTerm -> RError) -> pure $ mkTermRes RError
     -- Applying to `id` changes nothing.
     (getTerm -> RLamAbs 0 (RVar 0), y') -> pure y'
-    (getTerm -> RHoisted (HoistedTerm _ (RLamAbs 0 (RVar 0))), y') -> pure y'
+    (getTerm -> RHoisted (HoistedTerm _ _ (RLamAbs 0 (RVar 0))), y') -> pure y'
     -- append argument
     (x'@(getTerm -> RApply x'l x'r), y') -> pure $ TermResult (RApply x'l (getTerm y' : x'r)) (getDeps x' <> getDeps y')
     -- new RApply
@@ -721,7 +793,7 @@ punsafeConstant = punsafeConstantInternal
 
 punsafeConstantInternal :: Some (ValueOf PLC.DefaultUni) -> Term s a
 punsafeConstantInternal c = Term \_ ->
-  let hoisted = HoistedTerm (hashRawTerm $ RConstant c) (RConstant c)
+  let hoisted = HoistedTerm (hashRawTerm $ RConstant c) (hash $ RConstant c) (RConstant c)
    in pure $ TermResult (RHoisted hoisted) [hoisted]
 
 asClosedRawTerm :: ClosedTerm a -> TermMonad TermResult
@@ -818,9 +890,30 @@ smallEnoughToInline (Config _ (Last ch)) = \case
     getConstantSize c =
       toInteger $ SBS.length $ serialiseUPLC $ UPLC.Program () uplcVersion (UPLC.Constant () c)
 
--- The logic is mostly for hoisting
+-- | The compilation function itself.
+--
+-- NOTE: (choener) The @CMPOLD / -fcmpold@ switch allows comparing old and new
+-- compilation results. Caveat emptor: this won't always work, especially when
+-- multiple "co-optimal" optimization choices are made randomly by the old
+-- path. I have an idea to enforce optimal choice, but this will only be
+-- possiple long-term.
+
 compile' :: Config -> TermResult -> UTerm
-compile' cfg t =
+#ifdef CMPOLD
+compile' cfg t = unsafePerformIO $ do
+  let old = compile'old cfg t
+  let new = compile'new cfg t
+  if old == new
+  then pure old
+  else error $ "compile': old and new compilation pipeline differ!\n" ++ show (getTerm t)
+#else
+compile' = compile'new
+#endif
+
+-- The logic is mostly for hoisting
+compile'old :: Config -> TermResult -> UTerm
+-- BUG: (choener) If CMPOLD is not active, the DIG will be @()@ and thus this path is broken -- but also unused. Should be better protected, though.
+compile'old cfg t =
   let t' = getTerm t
       deps = getDeps t
 
@@ -832,29 +925,71 @@ compile' cfg t =
         HoistedTerm ->
         (M.Map Dig Word64, [(Word64, RawTerm)], Word64) ->
         (M.Map Dig Word64, [(Word64, RawTerm)], Word64)
-      g (HoistedTerm hash term) (m, defs, n) = case M.alterF (f n) hash m of
+      g (HoistedTerm hash _ term) (m, defs, n) = case M.alterF (f n) hash m of
         (True, m) -> (m, (n, term) : defs, n + 1)
         (False, m) -> (m, defs, n)
 
       hoistedTermRaw :: HoistedTerm -> RawTerm
-      hoistedTermRaw (HoistedTerm _ t) = t
+      hoistedTermRaw (HoistedTerm _ _ t) = t
 
       toInline :: S.Set Dig
       toInline =
         S.fromList
-          . fmap (\(HoistedTerm hash _) -> hash)
+          . fmap (\(HoistedTerm hash _ _) -> hash)
           . (head <$>)
           . filter (\terms -> length terms == 1 || smallEnoughToInline cfg (hoistedTermRaw $ head terms))
-          . groupBy (\(HoistedTerm x _) (HoistedTerm y _) -> x == y)
-          . sortOn (\(HoistedTerm hash _) -> hash)
+          . groupBy (\(HoistedTerm x _ _) (HoistedTerm y _ _) -> x == y)
+          . sortOn (\(HoistedTerm hash _ _) -> hash)
           $ deps
 
       -- map: term -> de Bruijn level
       -- defs: the terms, level 0 is last
       -- n: # of terms
-      (m, defs, n) = foldr g (M.empty, [], 0) $ filter (\(HoistedTerm hash _) -> not $ S.member hash toInline) deps
+      (m, defs, n) = foldr g (M.empty, [], 0) $ filter (\(HoistedTerm hash _ _) -> not $ S.member hash toInline) deps
 
-      map' (HoistedTerm hash term) l = case M.lookup hash m of
+      map' (HoistedTerm hash _ term) l = case M.lookup hash m of
+        Just l' -> UPLC.Var () . DeBruijn . Index $ l - l'
+        Nothing -> rawTermToUPLC map' l term
+
+      body = rawTermToUPLC map' n t'
+
+      wrapped =
+        foldl'
+          (\b (lvl, def) -> UPLC.Apply () (UPLC.LamAbs () (DeBruijn . Index $ 0) b) (rawTermToUPLC map' lvl def))
+          body
+          defs
+   in wrapped
+
+-- | The new compilation pipeline, not using cryptographic digests.
+
+compile'new :: Config -> TermResult -> UTerm
+compile'new cfg t =
+  let t' = getTerm t
+      deps = getDeps t
+
+      g :: HoistedTerm ->
+          (HM.HashMap HoistedTerm Word64, [(Word64, RawTerm)], Word64) ->
+          (HM.HashMap HoistedTerm Word64, [(Word64, RawTerm)], Word64)
+      g hoistedTerm@(HoistedTerm _ _ term) (m, defs, n) = case HM.lookup hoistedTerm m of
+        Nothing -> (HM.insert hoistedTerm n m, (n, term) : defs, n+1)
+        Just _w64 -> (m, defs, n)
+
+      toInline :: HM.HashMap HoistedTerm Int
+      toInline =
+        -- keep only count "1"s or small enough to inline ones
+        HM.filterWithKey (\(HoistedTerm _ _ term) count -> count == 1 || smallEnoughToInline cfg term) depsCount
+
+      -- count how often a hoisted term occurs
+      depsCount :: HM.HashMap HoistedTerm Int
+      depsCount = HM.fromListWith (+) . map (,1) $ deps
+
+      -- map: term -> de Bruijn level
+      -- defs: the terms, level 0 is last
+      -- n: # of terms
+      (m :: HM.HashMap HoistedTerm Word64, defs, n) =
+        foldr g (HM.empty, [], 0) $ filter (\hoistedTerm -> not $ HM.member hoistedTerm toInline) deps
+
+      map' hoistedTerm@(HoistedTerm _ _ term) l = case HM.lookup hoistedTerm m of
         Just l' -> UPLC.Var () . DeBruijn . Index $ l - l'
         Nothing -> rawTermToUPLC map' l term
 

--- a/Plutarch/Internal/Term.hs
+++ b/Plutarch/Internal/Term.hs
@@ -801,15 +801,23 @@ asClosedRawTerm t = asRawTerm t 0
 
 -- FIXME: Give proper error message when mutually recursive.
 phoistAcyclic :: HasCallStack => ClosedTerm a -> Term s a
+-- PERF: (choener) Short-circuiting the whole evaluation-for-debugging system
+-- for now. I should make this more lazy and have it compile on demand whenever
+-- compile for a whole script fails.
 phoistAcyclic t = pgetConfig $ \cfg -> Term \_ ->
   asRawTerm t 0 >>= \case
     -- Built-ins are smaller than variable references
     t'@(getTerm -> RBuiltin _) -> pure t'
+    {-
     t' -> case evalScript . Script . UPLC.Program () uplcVersion $ compile' cfg t' of
       (Right _, _, _) ->
-        let hoisted = HoistedTerm (hashRawTerm . getTerm $ t') (getTerm t')
+        let hoisted = HoistedTerm (hashRawTerm $ getTerm t') (hash $ getTerm t') (getTerm t')
          in pure $ TermResult (RHoisted hoisted) (hoisted : getDeps t')
       (Left e, _, _) -> pthrow' $ "Hoisted term errs! " <> fromString (show e)
+    -}
+    t' ->
+        let hoisted = HoistedTerm (hashRawTerm $ getTerm t') (hash $ getTerm t') (getTerm t')
+         in pure $ TermResult (RHoisted hoisted) (hoisted : getDeps t')
 
 -- Couldn't find a definition for this in plutus-core
 subst :: Word64 -> (Word64 -> UTerm) -> UTerm -> UTerm

--- a/plutarch.cabal
+++ b/plutarch.cabal
@@ -8,10 +8,21 @@ license:            MIT
 extra-source-files: README.md
 tested-with:        GHC ==9.6.6
 
+flag checkhoist
+  description: Enable compilation within phoist-acyclic
+  default:     False
+  manual:      True
+
+flag cmpold
+  description: Compare compiled code directly with old compilation
+  default:     False
+  manual:      True
+
 common c
   default-language:   GHC2021
   default-extensions:
     BlockArguments
+    CPP
     DataKinds
     DefaultSignatures
     DeriveAnyClass
@@ -72,6 +83,13 @@ common c
 
 library
   import:          c
+
+  if flag(cmpold)
+    cpp-options: -DCMPOLD
+
+  if flag(checkhoist)
+    cpp-options: -DCHECKHOIST
+
   exposed-modules:
     Plutarch.BitString
     Plutarch.Builtin
@@ -146,12 +164,14 @@ library
     , data-default
     , flat
     , generics-sop
+    , hashable
     , lens
     , mtl
-    , plutus-core        >=1.40.0.0 && <1.41
+    , plutus-core           >=1.40.0.0 && <1.41
     , plutus-ledger-api
     , plutus-tx
     , prettyprinter
     , QuickCheck
     , random
+    , unordered-containers
     , vector


### PR DESCRIPTION
Two patches related to Plutarch performance improvements

- The first patch establishes a new compilation pipeline and uses it throughout
- The second patch disables eager check-via-compilation

Notes:

- I have not checked that the first patch builds cleanly by itself
- Plutarch might be somewhat annoying to build outside of being Djed dependency, for testing you might want to change to this commit hash: `7fa72c29c9a330bfb9ce14ccfbf2f157d0047f38`
- There are some notes and todos which should be tackled, but we might want to see about getting some of this into Plutarch proper

